### PR TITLE
Fix overflow on mobile browsers

### DIFF
--- a/app/views/home.html.erb
+++ b/app/views/home.html.erb
@@ -1,7 +1,8 @@
-<section class="w3-container w3-flat-clouds w3-padding-64">
-    <form class="w3-container w3-center w3-flat-clouds w3-padding-64" action="/wiki/put" method="POST">
+<section class="w3-container w3-flat-clouds">
+    <form class="w3-center w3-flat-clouds" action="/wiki/put" method="POST">
         <%= csrf.form_tag %>
         <input type="hidden" name="_method" value="PUT">
+        <br>
         <label for="username">Username:<br>
             <input class="w3-input" type="text" name="username" id="username" placeholder="username" value="<%= @show_user_id %>"
                 required>
@@ -21,6 +22,7 @@
         <br>
         <input class="w3-button w3-center w3-flat-pomegranate" type="submit" value="Submit">
     </form>
+    <br>
 </section>
 <footer class="w3-container w3-center footer">
     <p>&copy; 2017 Derek Viera <br>

--- a/app/views/home.html.erb
+++ b/app/views/home.html.erb
@@ -1,8 +1,7 @@
-<section class="w3-container w3-flat-clouds">
-    <form class="w3-center w3-flat-clouds" action="/wiki/put" method="POST">
+<section class="w3-container w3-flat-clouds w3-padding-64">
+    <form class="w3-container w3-center w3-flat-clouds w3-padding-64" action="/wiki/put" method="POST">
         <%= csrf.form_tag %>
         <input type="hidden" name="_method" value="PUT">
-        <br>
         <label for="username">Username:<br>
             <input class="w3-input" type="text" name="username" id="username" placeholder="username" value="<%= @show_user_id %>"
                 required>
@@ -22,7 +21,6 @@
         <br>
         <input class="w3-button w3-center w3-flat-pomegranate" type="submit" value="Submit">
     </form>
-    <br>
 </section>
 <footer class="w3-container w3-center footer">
     <p>&copy; 2017 Derek Viera <br>

--- a/app/views/layout.html.erb
+++ b/app/views/layout.html.erb
@@ -15,7 +15,7 @@ to share with friends, family, &amp; the world.">
 
 <body>
         <header class="w3-container w3-center w3-flat-pomegranate w3-padding-64">
-                <h1 class="w3-jumbo">OpenMessages.info</h1>
+                <h1 class="w3-xxxlarge">OpenMessages<span class="w3-hide-small">.info</span></h1>
                 <div class="w3-dropdown-hover w3-padding-64">
                     <button class="w3-button w3-flat-clouds w3-card-4"><i class="w3-xxlarge material-icons">menu</i></button>
                     <div class="w3-dropdown-content w3-bar-block w3-border">


### PR DESCRIPTION
This pull request fixes the overflow on mobile browsers fix was associated with the H1 header being too long for small screens, hiding part of the title on small screens fixed the problem.